### PR TITLE
Theme: Get input default styles working

### DIFF
--- a/chakraTheme/components/Input.ts
+++ b/chakraTheme/components/Input.ts
@@ -1,0 +1,14 @@
+import cp from '@core-ds/primitives';
+
+const Input = {
+   parts: ['field'],
+   variants: {
+      outline: {
+         field: {
+            bg: cp.color.white,
+         },
+      },
+   },
+};
+
+export default Input;

--- a/chakraTheme/index.ts
+++ b/chakraTheme/index.ts
@@ -7,6 +7,7 @@ import colors from './foundations/colors';
 import space from './foundations/space';
 
 import Button from './components/Button';
+import Input from './components/Input';
 import Modal from './components/Modal';
 import Tabs from './components/Tabs';
 
@@ -17,6 +18,7 @@ const theme: Theme = extendTheme({
    space,
    components: {
       Button,
+      Input,
       Modal,
       Tabs,
    },


### PR DESCRIPTION
We needed to leverage `parts` to style the Input `field`: https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/input.ts#L3

qa_req 0